### PR TITLE
feat: make MolVis hero molecules link to molvis.molcrafts.org

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,15 @@ import { Navbar } from "./components/Navbar";
 import { Newsletter } from "./components/Newsletter";
 import {
   MolVisLanding,
-  MolpyLanding,
-  MolrecLanding,
   MolcfgLanding,
-  MollogLanding,
-  MolqLanding,
-  MolrsLanding,
   MolexpLanding,
+  MollogLanding,
   MolnexLanding,
   MolpackLanding,
+  MolpyLanding,
+  MolqLanding,
+  MolrecLanding,
+  MolrsLanding,
   NotFound,
 } from "./pages";
 

--- a/src/components/Community.tsx
+++ b/src/components/Community.tsx
@@ -56,7 +56,9 @@ export const Community = () => {
 
           {/* Discord/Forum Card */}
           <motion.a
-            href="#"
+            href="https://github.com/MolCrafts"
+            target="_blank"
+            rel="noreferrer noopener"
             className="group flex flex-col items-center text-center p-6 transition-all"
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,5 +1,5 @@
-import type { SVGProps } from "react";
 import moko from "@/assets/moko/moko.png";
+import type { SVGProps } from "react";
 
 export const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (

--- a/src/components/MoleculeOverlay.tsx
+++ b/src/components/MoleculeOverlay.tsx
@@ -7,6 +7,7 @@ import dopamineMolecule from "@/assets/molecules/dopamine.webp";
 import ibuprofenMolecule from "@/assets/molecules/ibuprofen.webp";
 import nicotineMolecule from "@/assets/molecules/nicotine.webp";
 import quinineMolecule from "@/assets/molecules/quinine.webp";
+import { cn } from "@/lib/utils";
 
 const MOLECULES = [
   aspirinMolecule,
@@ -37,6 +38,7 @@ function useSlot(
   showMs: number,
   periodMs: number,
   initialDelayMs: number,
+  excludeImgIdxRef?: { current: number },
 ): SlotState {
   const [state, setState] = useState<SlotState>({
     visible: false,
@@ -52,11 +54,18 @@ function useSlot(
   const show = useCallback(() => {
     const top = `${rand(yMin, yMax).toFixed(1)}%`;
     const left = `${rand(xMin, xMax).toFixed(1)}%`;
-    const imgIdx = Math.floor(Math.random() * MOLECULES.length);
+    const exclude = excludeImgIdxRef?.current ?? -1;
+    let imgIdx: number;
+    if (exclude >= 0 && MOLECULES.length > 1) {
+      imgIdx = Math.floor(Math.random() * (MOLECULES.length - 1));
+      if (imgIdx >= exclude) imgIdx += 1;
+    } else {
+      imgIdx = Math.floor(Math.random() * MOLECULES.length);
+    }
     setState((s) => ({ visible: true, uid: s.uid + 1, imgIdx, top, left }));
     if (hideTimerRef.current !== null) clearTimeout(hideTimerRef.current);
     hideTimerRef.current = setTimeout(() => setState((s) => ({ ...s, visible: false })), showMs);
-  }, [xMin, xMax, yMin, yMax, showMs]);
+  }, [xMin, xMax, yMin, yMax, showMs, excludeImgIdxRef]);
 
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | null = null;
@@ -75,97 +84,226 @@ function useSlot(
   return state;
 }
 
-export const MoleculeOverlay = () => {
-  // Left edge slot — cycles every 7.5s, visible 4.5s
-  const leftSlot = useSlot(3, 16, 15, 78, 4500, 7500, 700);
-  // Right edge slot — cycles every 8.5s, visible 4.5s, offset start
-  const rightSlot = useSlot(81, 93, 15, 78, 4500, 8500, 2800);
+type Placement = "edges" | "spotlight";
+
+interface PlacementPreset {
+  range: [number, number, number, number];
+  sizeClass: string;
+  showMs: number;
+  periodMs: number;
+  initialDelayMs: number;
+}
+
+const PLACEMENTS: Record<Placement, { left: PlacementPreset; right: PlacementPreset }> = {
+  edges: {
+    left: {
+      range: [3, 16, 15, 78],
+      sizeClass: "w-36 h-36 md:w-44 md:h-44",
+      showMs: 4500,
+      periodMs: 7500,
+      initialDelayMs: 700,
+    },
+    right: {
+      range: [81, 93, 15, 78],
+      sizeClass: "w-40 h-40 md:w-52 md:h-52",
+      showMs: 4500,
+      periodMs: 8500,
+      initialDelayMs: 2800,
+    },
+  },
+  spotlight: {
+    left: {
+      range: [10, 22, 18, 80],
+      sizeClass: "w-48 h-48 md:w-60 md:h-60",
+      showMs: 5500,
+      periodMs: 7000,
+      initialDelayMs: 500,
+    },
+    right: {
+      range: [78, 90, 18, 80],
+      sizeClass: "w-52 h-52 md:w-64 md:h-64",
+      showMs: 5500,
+      periodMs: 7500,
+      initialDelayMs: 2500,
+    },
+  },
+};
+
+const LEFT_MOTION = {
+  initial: { opacity: 0, scale: 0.82, y: 0, rotate: -8 },
+  animate: {
+    opacity: 0.82,
+    scale: 1,
+    y: [0, -22, 0, 22, 0],
+    rotate: [-8, 8],
+  },
+  transition: {
+    opacity: { duration: 1, ease: "easeOut" },
+    scale: { duration: 1, ease: "easeOut" },
+    y: { duration: 8, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut" },
+    rotate: {
+      duration: 10,
+      repeat: Number.POSITIVE_INFINITY,
+      repeatType: "reverse" as const,
+      ease: "easeInOut",
+    },
+  },
+  exit: { opacity: 0, scale: 0.88, transition: { duration: 1, ease: "easeIn" } },
+};
+
+const RIGHT_MOTION = {
+  initial: { opacity: 0, scale: 0.82, y: 0, rotate: 6 },
+  animate: {
+    opacity: 0.88,
+    scale: 1,
+    y: [0, 24, 0, -24, 0],
+    rotate: [6, -6],
+  },
+  transition: {
+    opacity: { duration: 1, ease: "easeOut" },
+    scale: { duration: 1, ease: "easeOut" },
+    y: { duration: 9, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut" },
+    rotate: {
+      duration: 11,
+      repeat: Number.POSITIVE_INFINITY,
+      repeatType: "reverse" as const,
+      ease: "easeInOut",
+    },
+  },
+  exit: { opacity: 0, scale: 0.88, transition: { duration: 1, ease: "easeIn" } },
+};
+
+const HINT_CLASSES =
+  "absolute left-1/2 top-full -translate-x-1/2 mt-3 whitespace-nowrap text-xs md:text-sm font-['Outfit',sans-serif] tracking-[0.2em] uppercase text-zinc-300/85 group-hover:text-fuchsia-300 transition-colors";
+
+interface MoleculeOverlayProps {
+  href?: string;
+  hintLabel?: string;
+  placement?: Placement;
+}
+
+export const MoleculeOverlay = ({
+  href,
+  hintLabel = "Open live demo ↗",
+  placement = "edges",
+}: MoleculeOverlayProps = {}) => {
+  const preset = PLACEMENTS[placement];
+  const [lx1, lx2, ly1, ly2] = preset.left.range;
+  const [rx1, rx2, ry1, ry2] = preset.right.range;
+
+  const leftImgIdxRef = useRef<number>(-1);
+  const rightImgIdxRef = useRef<number>(-1);
+
+  const leftSlot = useSlot(
+    lx1,
+    lx2,
+    ly1,
+    ly2,
+    preset.left.showMs,
+    preset.left.periodMs,
+    preset.left.initialDelayMs,
+    rightImgIdxRef,
+  );
+  const rightSlot = useSlot(
+    rx1,
+    rx2,
+    ry1,
+    ry2,
+    preset.right.showMs,
+    preset.right.periodMs,
+    preset.right.initialDelayMs,
+    leftImgIdxRef,
+  );
+
+  leftImgIdxRef.current = leftSlot.visible ? leftSlot.imgIdx : -1;
+  rightImgIdxRef.current = rightSlot.visible ? rightSlot.imgIdx : -1;
+
+  const interactive = Boolean(href);
+  const positionStyle = (slot: SlotState) => ({
+    top: slot.top,
+    left: slot.left,
+    transform: "translate(-50%, -50%)",
+  });
 
   return (
-    <div className="absolute inset-0 pointer-events-none overflow-hidden">
+    <div
+      className={cn("absolute inset-0 pointer-events-none overflow-hidden", interactive && "z-20")}
+    >
       <AnimatePresence>
-        {leftSlot.visible && (
-          <motion.img
-            key={`left-${leftSlot.uid}`}
-            src={MOLECULES[leftSlot.imgIdx]}
-            alt="Molecule"
-            className="absolute pointer-events-none z-10 w-36 h-36 md:w-44 md:h-44 object-contain select-none molecule-glow-effect"
-            style={{
-              top: leftSlot.top,
-              left: leftSlot.left,
-              transform: "translate(-50%, -50%)",
-            }}
-            initial={{ opacity: 0, scale: 0.82, y: 0, rotate: -8 }}
-            animate={{
-              opacity: 0.82,
-              scale: 1,
-              y: [0, -22, 0, 22, 0],
-              rotate: [-8, 8],
-            }}
-            transition={{
-              opacity: { duration: 1, ease: "easeOut" },
-              scale: { duration: 1, ease: "easeOut" },
-              y: {
-                duration: 8,
-                repeat: Number.POSITIVE_INFINITY,
-                ease: "easeInOut",
-              },
-              rotate: {
-                duration: 10,
-                repeat: Number.POSITIVE_INFINITY,
-                repeatType: "reverse",
-                ease: "easeInOut",
-              },
-            }}
-            exit={{
-              opacity: 0,
-              scale: 0.88,
-              transition: { duration: 1, ease: "easeIn" },
-            }}
-            draggable="false"
-          />
-        )}
-        {rightSlot.visible && (
-          <motion.img
-            key={`right-${rightSlot.uid}`}
-            src={MOLECULES[rightSlot.imgIdx]}
-            alt="Molecule"
-            className="absolute pointer-events-none z-10 w-40 h-40 md:w-52 md:h-52 object-contain select-none molecule-glow-effect"
-            style={{
-              top: rightSlot.top,
-              left: rightSlot.left,
-              transform: "translate(-50%, -50%)",
-            }}
-            initial={{ opacity: 0, scale: 0.82, y: 0, rotate: 6 }}
-            animate={{
-              opacity: 0.88,
-              scale: 1,
-              y: [0, 24, 0, -24, 0],
-              rotate: [6, -6],
-            }}
-            transition={{
-              opacity: { duration: 1, ease: "easeOut" },
-              scale: { duration: 1, ease: "easeOut" },
-              y: {
-                duration: 9,
-                repeat: Number.POSITIVE_INFINITY,
-                ease: "easeInOut",
-              },
-              rotate: {
-                duration: 11,
-                repeat: Number.POSITIVE_INFINITY,
-                repeatType: "reverse",
-                ease: "easeInOut",
-              },
-            }}
-            exit={{
-              opacity: 0,
-              scale: 0.88,
-              transition: { duration: 1, ease: "easeIn" },
-            }}
-            draggable="false"
-          />
-        )}
+        {leftSlot.visible &&
+          (interactive ? (
+            <motion.a
+              key={`left-${leftSlot.uid}`}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={hintLabel}
+              className={cn(
+                "absolute z-20 pointer-events-auto select-none cursor-pointer group",
+                preset.left.sizeClass,
+              )}
+              style={positionStyle(leftSlot)}
+              {...LEFT_MOTION}
+            >
+              <img
+                src={MOLECULES[leftSlot.imgIdx]}
+                alt="Molecule"
+                className="w-full h-full object-contain molecule-glow-effect transition-transform duration-300 group-hover:scale-105"
+                draggable="false"
+              />
+              <span className={HINT_CLASSES}>{hintLabel}</span>
+            </motion.a>
+          ) : (
+            <motion.img
+              key={`left-${leftSlot.uid}`}
+              src={MOLECULES[leftSlot.imgIdx]}
+              alt="Molecule"
+              className={cn(
+                "absolute pointer-events-none z-10 object-contain select-none molecule-glow-effect",
+                preset.left.sizeClass,
+              )}
+              style={positionStyle(leftSlot)}
+              {...LEFT_MOTION}
+              draggable="false"
+            />
+          ))}
+        {rightSlot.visible &&
+          (interactive ? (
+            <motion.a
+              key={`right-${rightSlot.uid}`}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={hintLabel}
+              className={cn(
+                "absolute z-20 pointer-events-auto select-none cursor-pointer group",
+                preset.right.sizeClass,
+              )}
+              style={positionStyle(rightSlot)}
+              {...RIGHT_MOTION}
+            >
+              <img
+                src={MOLECULES[rightSlot.imgIdx]}
+                alt="Molecule"
+                className="w-full h-full object-contain molecule-glow-effect transition-transform duration-300 group-hover:scale-105"
+                draggable="false"
+              />
+              <span className={HINT_CLASSES}>{hintLabel}</span>
+            </motion.a>
+          ) : (
+            <motion.img
+              key={`right-${rightSlot.uid}`}
+              src={MOLECULES[rightSlot.imgIdx]}
+              alt="Molecule"
+              className={cn(
+                "absolute pointer-events-none z-10 object-contain select-none molecule-glow-effect",
+                preset.right.sizeClass,
+              )}
+              style={positionStyle(rightSlot)}
+              {...RIGHT_MOTION}
+              draggable="false"
+            />
+          ))}
       </AnimatePresence>
     </div>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,13 +1,20 @@
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 
 import { GitHubLogoIcon } from "@radix-ui/react-icons";
 import { ChevronDown, Menu } from "lucide-react";
 import { ecosystemCategories } from "../lib/ecosystem";
-import { Button } from "./ui/button";
 import { LogoIcon } from "./Icons";
 import { ModeToggle } from "./mode-toggle";
+import { Button } from "./ui/button";
 
 export const Navbar = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -238,13 +245,14 @@ export const Navbar = () => {
                       Docs
                     </a>
                   ) : (
-                    <a
-                      href="#manifesto"
-                      onClick={() => setIsOpen(false)}
-                      className="flex items-center gap-3 px-4 py-3 rounded-xl hover:bg-accent transition-all font-medium"
-                    >
-                      Manifesto
-                    </a>
+                    <SheetClose asChild>
+                      <a
+                        href="#manifesto"
+                        className="flex items-center gap-3 px-4 py-3 rounded-xl hover:bg-accent transition-all font-medium"
+                      >
+                        Manifesto
+                      </a>
+                    </SheetClose>
                   )}
 
                   <div className="mt-8 pt-6 border-t dark:border-zinc-800 flex flex-col gap-4">

--- a/src/components/Team.tsx
+++ b/src/components/Team.tsx
@@ -1,4 +1,4 @@
-import { Github, Twitter } from "lucide-react";
+import { Github } from "lucide-react";
 
 interface ContributorProps {
   imageUrl: string;
@@ -77,15 +77,6 @@ export const Team = () => {
                     aria-label={`${name}'s GitHub`}
                   >
                     <Github size={16} />
-                  </a>
-                  <a
-                    rel="noreferrer noopener"
-                    href="#"
-                    target="_blank"
-                    className="text-zinc-500 hover:text-[#1da1f2] transition-colors"
-                    aria-label={`${name}'s Twitter`}
-                  >
-                    <Twitter size={16} />
                   </a>
                 </div>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -587,12 +587,10 @@ canvas * {
   }
 }
 
-/* Disable selection for molecule images */
 .select-none {
   user-select: none;
   -webkit-user-drag: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
-  pointer-events: none;
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
+import sadMoko from "@/assets/moko/sad.png";
 import { motion } from "framer-motion";
 import { Suspense, lazy } from "react";
 import { fadeIn, slideUp } from "../lib/animations";
-import sadMoko from "@/assets/moko/sad.png";
 
 // Lazy load the MoleculeOverlay component
 const MoleculeOverlay = lazy(() =>
@@ -53,11 +53,19 @@ export const NotFound = () => {
         variants={slideUp}
       >
         <motion.header className="flex flex-col items-center justify-center w-full">
-          {/* Sad moko mascot */}
+          {/* Sad moko mascot — feathered into the backdrop, mint halo to match the page */}
           <motion.img
             src={sadMoko}
             alt="Moko"
-            className="w-28 h-28 md:w-36 md:h-36 object-contain mb-4"
+            className="w-36 h-36 md:w-44 md:h-44 object-cover mb-4"
+            style={{
+              WebkitMaskImage:
+                "radial-gradient(circle at center, #000 42%, rgba(0,0,0,0.65) 60%, transparent 78%)",
+              maskImage:
+                "radial-gradient(circle at center, #000 42%, rgba(0,0,0,0.65) 60%, transparent 78%)",
+              filter:
+                "drop-shadow(0 0 28px rgba(16,185,129,0.28)) drop-shadow(0 0 12px rgba(140,228,255,0.18))",
+            }}
             initial={{ opacity: 0, scale: 0.88 }}
             animate={{ opacity: 1, scale: 1, y: [0, -8, 0] }}
             transition={{

--- a/src/pages/molexp/MolexpLanding.tsx
+++ b/src/pages/molexp/MolexpLanding.tsx
@@ -2,14 +2,7 @@ import { motion, useInView } from "framer-motion";
 import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
-import {
-  AnalysisIcon,
-  CollaborationIcon,
-  DataIcon,
-  IntegrationIcon,
-  SimulationIcon,
-  WorkflowIcon,
-} from "../../components/FeatureIcons";
+import { DataIcon, IntegrationIcon, WorkflowIcon } from "../../components/FeatureIcons";
 import { fadeIn, slideUp, staggerContainer } from "../../lib/animations";
 
 const MoleculeOverlay = lazy(() =>

--- a/src/pages/molnex/MolnexLanding.tsx
+++ b/src/pages/molnex/MolnexLanding.tsx
@@ -2,14 +2,7 @@ import { motion, useInView } from "framer-motion";
 import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
-import {
-  AnalysisIcon,
-  CollaborationIcon,
-  DataIcon,
-  IntegrationIcon,
-  SimulationIcon,
-  WorkflowIcon,
-} from "../../components/FeatureIcons";
+import { DataIcon, IntegrationIcon, WorkflowIcon } from "../../components/FeatureIcons";
 import { fadeIn, slideUp, staggerContainer } from "../../lib/animations";
 
 const MoleculeOverlay = lazy(() =>

--- a/src/pages/molrec/MolrecLanding.tsx
+++ b/src/pages/molrec/MolrecLanding.tsx
@@ -140,9 +140,9 @@ export const MolrecLanding = () => {
                 description:
                   "Frames can hold atoms, bonds, angles, beads, fragments, and volumetric grids as first-class record elements.",
               },
-            ].map((feature, idx) => (
+            ].map((feature) => (
               <motion.div
-                key={idx}
+                key={feature.title}
                 className="flex flex-col items-center text-center group"
                 variants={slideUp}
               >

--- a/src/pages/molrs/MolrsLanding.tsx
+++ b/src/pages/molrs/MolrsLanding.tsx
@@ -2,14 +2,7 @@ import { motion, useInView } from "framer-motion";
 import { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
-import {
-  AnalysisIcon,
-  CollaborationIcon,
-  DataIcon,
-  IntegrationIcon,
-  SimulationIcon,
-  WorkflowIcon,
-} from "../../components/FeatureIcons";
+import { DataIcon, IntegrationIcon, WorkflowIcon } from "../../components/FeatureIcons";
 import { fadeIn, slideUp, staggerContainer } from "../../lib/animations";
 
 const MoleculeOverlay = lazy(() =>

--- a/src/pages/molvis/MolvisLanding.tsx
+++ b/src/pages/molvis/MolvisLanding.tsx
@@ -126,9 +126,9 @@ export const MolVisLanding = () => {
                 description:
                   "The same codebase ships a core package, React web app, Python Jupyter widget, and VSCode extension with a modular modifier pipeline.",
               },
-            ].map((feature, idx) => (
+            ].map((feature) => (
               <motion.div
-                key={idx}
+                key={feature.title}
                 className="flex flex-col items-center text-center group"
                 variants={slideUp}
               >

--- a/src/pages/molvis/MolvisLanding.tsx
+++ b/src/pages/molvis/MolvisLanding.tsx
@@ -42,7 +42,11 @@ export const MolVisLanding = () => {
         />
 
         <Suspense fallback={null}>
-          <MoleculeOverlay />
+          <MoleculeOverlay
+            href="https://molvis.molcrafts.org"
+            hintLabel="Try It Live ↗"
+            placement="spotlight"
+          />
         </Suspense>
 
         <motion.div


### PR DESCRIPTION
## Summary
- MoleculeOverlay now accepts optional `href`/`hintLabel`/`placement` props; when `href` is set, molecules render as `<motion.a>` with a hover hint and open in a new tab.
- MolVis landing wires the overlay to `https://molvis.molcrafts.org` with the `spotlight` placement preset (larger molecules, closer to the hero text).
- Removes `pointer-events: none` from the global `.select-none` rule in `src/index.css` that was hijacking Tailwind's utility and silently killing clicks on anything combining `select-none` with `pointer-events-auto` — the reason the click-through wasn't working in the first place.

## Why the CSS change is safe
- Non-interactive molecules in MoleculeOverlay already declare `pointer-events-none` explicitly, so their behavior is unchanged.
- Other `select-none` consumers (`ui/dropdown-menu`, `EcosystemArchitecture` divider) expected Tailwind's semantics; the override was only intended to prevent dragging of molecule images, which is still covered by `-webkit-user-drag: none` and friends.

## Test plan
- [ ] `npm run dev`, visit `/molvis`, wait for molecules to fade in, click one → new tab to `molvis.molcrafts.org`
- [ ] Hover a molecule → "Try It Live ↗" hint visible, scale-up transition plays
- [ ] Confirm homepage `MoleculeOverlay` (no `href`) still renders as non-interactive image (no pointer cursor)
- [ ] Confirm ecosystem architecture dividers and Radix dropdowns still behave normally